### PR TITLE
Fix text-halo-fill.

### DIFF
--- a/lib/cartoRenderer.js
+++ b/lib/cartoRenderer.js
@@ -1024,7 +1024,7 @@ var cartoImageRenderer = function (ctx, scale, layers, styles, zoom, minX, maxX,
                 if (instanceStyle["text-halo-fill"]) {
                   ctx.strokeStyle = instanceStyle["text-halo-fill"].toString();
                   if (instanceStyle["text-halo-radius"]) {
-                    ctx.lineWidth = instanceStyle["text-halo-radius"].value * 2;
+                    ctx.lineWidth = parseInt(instanceStyle["text-halo-radius"] || 1) * 2;
                   }
 
                   // definitely DON'T leave this set to miter :P


### PR DESCRIPTION
text-halo-radius was unresponsive due to `.value`. Corrected with `parseInt()` and confirmed using tile demos.