### PR TITLE
Carto 1.2.0 compatibility

### DIFF
--- a/lib/cartoRenderer.js
+++ b/lib/cartoRenderer.js
@@ -1364,7 +1364,6 @@ exports.processStyles = function(styles, assetsPath) {
   var imageCache = {};
   var ref = new carto.tree.Reference();
   ref.setVersion(ref.getLatest());  // Loads mapnik-reference data into the ref
-  console.log(ref);
 
   styles.forEach(function(cartoString, index) {
     var env = {

--- a/lib/cartoRenderer.js
+++ b/lib/cartoRenderer.js
@@ -1362,6 +1362,7 @@ var cartoSelectorIsMatch = function(definition, feature, source, zoom) {
 exports.processStyles = function(styles, assetsPath) {
   var processed = [];
   var imageCache = {};
+  var ref = new carto.tree.Reference();
 
   styles.forEach(function(cartoString, index) {
     var env = {
@@ -1369,7 +1370,8 @@ exports.processStyles = function(styles, assetsPath) {
       frames: [],
       error: function(error) {
         console.error("Carto parsing error: ", error);
-      }
+      },
+      ref: ref
     };
     try {
       var parsed = (carto.Parser(env)).parse(cartoString);

--- a/lib/cartoRenderer.js
+++ b/lib/cartoRenderer.js
@@ -1376,6 +1376,7 @@ exports.processStyles = function(styles, assetsPath) {
     }
     catch(ex) {
       console.error("Error parsing Carto style #" + index + ": " + ex + "\n" + cartoString + "\n\n");
+      console.error(ex.stack);
       return;
     }
 

--- a/lib/cartoRenderer.js
+++ b/lib/cartoRenderer.js
@@ -1363,7 +1363,7 @@ exports.processStyles = function(styles, assetsPath) {
   var processed = [];
   var imageCache = {};
   var ref = new carto.tree.Reference();
-  ref.setVersion(ref.latest);  // Loads mapnik-reference data into the ref
+  ref.setVersion(ref.getLatest());  // Loads mapnik-reference data into the ref
   console.log(ref);
 
   styles.forEach(function(cartoString, index) {

--- a/lib/cartoRenderer.js
+++ b/lib/cartoRenderer.js
@@ -1363,9 +1363,8 @@ exports.processStyles = function(styles, assetsPath) {
   var processed = [];
   var imageCache = {};
   var ref = new carto.tree.Reference();
-  console.log('ref compliant', ref.checkCompliance(ref));
+  ref.setVersion(ref.latest);  // Loads mapnik-reference data into the ref
   console.log(ref);
-  console.log(JSON.stringify(ref, null, 1));
 
   styles.forEach(function(cartoString, index) {
     var env = {

--- a/lib/cartoRenderer.js
+++ b/lib/cartoRenderer.js
@@ -1363,6 +1363,9 @@ exports.processStyles = function(styles, assetsPath) {
   var processed = [];
   var imageCache = {};
   var ref = new carto.tree.Reference();
+  console.log('ref compliant', ref.checkCompliance(ref));
+  console.log(ref);
+  console.log(JSON.stringify(ref, null, 1));
 
   styles.forEach(function(cartoString, index) {
     var env = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodetiles-core",
-  "version": "0.1.1",
+  "version": "0.1.5",
   "description": "Joyful map rendering with Node.js.",
   "contributors": [
     {


### PR DESCRIPTION
This is required for https://github.com/loveland/tiles/pull/610, for the carto update from 0.9.5 to 1.2.0. Has been running on stage-tiles since Aug 1. 